### PR TITLE
101 multi app projects

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,20 +1,16 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
 django = "==1.11.4"
 graphql-py = "==0.6.0"
 ply = "==3.10"
 pytz = "==2017.2"
-
+six = "*"
 
 [dev-packages]
-
 "backports.unittest-mock" = "==1.2"
 configparser = "==3.5.0"
 "enum34" = "==1.1.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,20 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9386f27a8e7c0f1ed30b3fc94a90d7d804b6897c387e8b0aa3dfe339fb2ba9bd"
-        },
-        "host-environment-markers": {
-            "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
-            "os_name": "posix",
-            "platform_machine": "x86_64",
-            "platform_python_implementation": "CPython",
-            "platform_release": "17.3.0",
-            "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.3.0: Thu Nov  9 18:09:22 PST 2017; root:xnu-4570.31.3~1/RELEASE_X86_64",
-            "python_full_version": "3.6.3",
-            "python_version": "3.6",
-            "sys_platform": "darwin"
+            "sha256": "376f09f87451f3d99ea748981de8ee5b449142847c4c492f3f9d6fb792bd543f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -32,33 +19,45 @@
                 "sha256:6fd30e05dc9af265f7d7d10cfb0efa013e6236db0853c9f47c74c585587c5a57",
                 "sha256:abe86e67dda9897a1536a727ed57dbefb5a42b41943be3b116fe3edab4c07bb2"
             ],
+            "index": "pypi",
             "version": "==1.11.4"
         },
         "graphql-py": {
             "hashes": [
                 "sha256:a76eae52f9502d37316e68c9d75a76064f65f59fa96478967ea85bdef5b966dc"
             ],
+            "index": "pypi",
             "version": "==0.6.0"
         },
         "ply": {
             "hashes": [
                 "sha256:96e94af7dd7031d8d6dd6e2a8e0de593b511c211a86e28a9c9621c275ac8bacb"
             ],
+            "index": "pypi",
             "version": "==3.10"
         },
         "pytz": {
             "hashes": [
-                "sha256:c883c2d6670042c7bc1688645cac73dd2b03193d1f7a6847b6154e96890be06d",
                 "sha256:03c9962afe00e503e2d96abab4e8998a0f84d4230fa57afe1e0528473698cdd9",
-                "sha256:487e7d50710661116325747a9cd1744d3323f8e49748e287bc9e659060ec6bf9",
-                "sha256:43f52d4c6a0be301d53ebd867de05e2926c35728b3260157d274635a0a947f1c",
-                "sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67",
-                "sha256:54a935085f7bf101f86b2aff75bd9672b435f51c3339db2ff616e66845f2b8f9",
                 "sha256:39504670abb5dae77f56f8eb63823937ce727d7cdd0088e6909e6dcac0f89043",
+                "sha256:43f52d4c6a0be301d53ebd867de05e2926c35728b3260157d274635a0a947f1c",
+                "sha256:487e7d50710661116325747a9cd1744d3323f8e49748e287bc9e659060ec6bf9",
+                "sha256:54a935085f7bf101f86b2aff75bd9672b435f51c3339db2ff616e66845f2b8f9",
+                "sha256:c883c2d6670042c7bc1688645cac73dd2b03193d1f7a6847b6154e96890be06d",
+                "sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67",
                 "sha256:ddc93b6d41cfb81266a27d23a79e13805d4a5521032b512643af8729041a81b4",
                 "sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589"
             ],
+            "index": "pypi",
             "version": "==2017.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "index": "pypi",
+            "version": "==1.11.0"
         }
     },
     "develop": {
@@ -71,83 +70,79 @@
         },
         "babel": {
             "hashes": [
-                "sha256:ad209a68d7162c4cff4b29cdebe3dec4cef75492df501b0049a9433c96ce6f80",
-                "sha256:8ce4cb6fdd4393edd323227cba3a077bceb2a6ce5201c902c65e730046f41f14"
+                "sha256:8ce4cb6fdd4393edd323227cba3a077bceb2a6ce5201c902c65e730046f41f14",
+                "sha256:ad209a68d7162c4cff4b29cdebe3dec4cef75492df501b0049a9433c96ce6f80"
             ],
             "version": "==2.5.3"
         },
         "backports.unittest-mock": {
             "hashes": [
-                "sha256:fbb579bea31e221ee048c0d870b000328caf61bae4a3915c465297761ed4aa23",
-                "sha256:56e79753f6eb2bc00a46269d17f521e475d59bdda809737b2eef04557cc39ddc"
+                "sha256:56e79753f6eb2bc00a46269d17f521e475d59bdda809737b2eef04557cc39ddc",
+                "sha256:fbb579bea31e221ee048c0d870b000328caf61bae4a3915c465297761ed4aa23"
             ],
+            "index": "pypi",
             "version": "==1.2"
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "chardet": {
             "hashes": [
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
-                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.3.9"
         },
         "configparser": {
             "hashes": [
                 "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
             ],
+            "index": "pypi",
             "version": "==3.5.0"
         },
         "docutils": {
             "hashes": [
-                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6",
                 "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
-                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
             ],
             "version": "==0.14"
         },
         "enum34": {
             "hashes": [
-                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
                 "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
-                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
-                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
             ],
+            "index": "pypi",
             "version": "==1.1.6"
         },
         "flake8": {
             "hashes": [
-                "sha256:f1a9d8886a9cbefb52485f4f4c770832c7fb569c084a9a314fb1eaa37c0c2c86",
-                "sha256:c20044779ff848f67f89c56a0e4624c04298cd476e25253ac0c36f910a1a11d8"
+                "sha256:c20044779ff848f67f89c56a0e4624c04298cd476e25253ac0c36f910a1a11d8",
+                "sha256:f1a9d8886a9cbefb52485f4f4c770832c7fb569c084a9a314fb1eaa37c0c2c86"
             ],
+            "index": "pypi",
             "version": "==3.4.1"
         },
         "idna": {
             "hashes": [
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
             ],
             "version": "==2.6"
         },
         "imagesize": {
             "hashes": [
-                "sha256:6ebdc9e0ad188f9d1b2cdd9bc59cbe42bf931875e829e7a595e6b3abdc05cdfb",
-                "sha256:0ab2c62b87987e3252f89d30b7cedbec12a01af9274af9ffa48108f2c13c6062"
+                "sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18",
+                "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
             ],
-            "version": "==0.7.1"
+            "version": "==1.0.0"
         },
         "jinja2": {
             "hashes": [
@@ -167,27 +162,38 @@
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
+            "index": "pypi",
             "version": "==0.6.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
+                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
+            ],
+            "version": "==17.1"
         },
         "py": {
             "hashes": [
-                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
-                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3",
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a"
             ],
+            "index": "pypi",
             "version": "==1.4.34"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
+                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
+                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],
+            "index": "pypi",
             "version": "==2.3.1"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:cc5eadfb38041f8366128786b4ca12700ed05bbf1403d808e89d57d67a3875a7",
-                "sha256:aa0d4dff45c0cc2214ba158d29280f8fa1129f3e87858ef825930845146337f4"
+                "sha256:aa0d4dff45c0cc2214ba158d29280f8fa1129f3e87858ef825930845146337f4",
+                "sha256:cc5eadfb38041f8366128786b4ca12700ed05bbf1403d808e89d57d67a3875a7"
             ],
+            "index": "pypi",
             "version": "==1.5.0"
         },
         "pygments": {
@@ -197,11 +203,24 @@
             ],
             "version": "==2.2.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
+                "sha256:281683241b25fe9b80ec9d66017485f6deff1af5cde372469134b56ca8447a07",
+                "sha256:8f1e18d3fd36c6795bb7e02a39fd05c611ffc2596c1e0d995d34d67630426c18",
+                "sha256:9e8143a3e15c13713506886badd96ca4b579a87fbdf49e550dbfc057d6cb218e",
+                "sha256:b8b3117ed9bdf45e14dcc89345ce638ec7e0e29b2b579fa1ecf32ce45ebac8a5",
+                "sha256:e4d45427c6e20a59bf4f88c639dcc03ce30d193112047f94012102f235853a58",
+                "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010"
+            ],
+            "version": "==2.2.0"
+        },
         "pytest": {
             "hashes": [
-                "sha256:82c1e44a964ec5922c7c3891787df31c8c4f18b6c97a722df56b6cf20bb38c8a",
-                "sha256:4c2159d2be2b4e13fa293e7a72bdf2f06848a017150d5c6d35112ce51cfd74ce"
+                "sha256:4c2159d2be2b4e13fa293e7a72bdf2f06848a017150d5c6d35112ce51cfd74ce",
+                "sha256:82c1e44a964ec5922c7c3891787df31c8c4f18b6c97a722df56b6cf20bb38c8a"
             ],
+            "index": "pypi",
             "version": "==3.2.1"
         },
         "pytest-django": {
@@ -209,27 +228,30 @@
                 "sha256:00995c2999b884a38ae9cd30a8c00ed32b3d38c1041250ea84caf18085589662",
                 "sha256:038ccc5a9daa1b1b0eb739ab7dce54e495811eca5ea3af4815a2a3ac45152309"
             ],
+            "index": "pypi",
             "version": "==3.1.2"
         },
         "pytest-pythonpath": {
             "hashes": [
                 "sha256:2d506b8d7dbc2535a16c888211b7319ad32b3e73444bd9dbb1dd19427a6c7414"
             ],
+            "index": "pypi",
             "version": "==0.7.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:80af0f3008046b9975242012a985f04c5df1f01eed4ec1633d56cc47a75a6a48",
-                "sha256:feb2365914948b8620347784b6b6da356f31c9d03560259070b2f30cff3d469d",
-                "sha256:59707844a9825589878236ff2f4e0dc9958511b7ffaae94dc615da07d4a68d33",
-                "sha256:d0ef5ef55ed3d37854320d4926b04a4cb42a2e88f71da9ddfdacfde8e364f027",
-                "sha256:c41c62827ce9cafacd6f2f7018e4f83a6f1986e87bfd000b8cfbd4ab5da95f1a",
-                "sha256:8cc90340159b5d7ced6f2ba77694d946fc975b09f1a51d93f3ce3bb399396f94",
-                "sha256:dd2e4ca6ce3785c8dd342d1853dd9052b19290d5bf66060846e5dc6b8d6667f7",
-                "sha256:699d18a2a56f19ee5698ab1123bbcc1d269d061996aeb1eda6d89248d3542b82",
-                "sha256:fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7"
+                "sha256:03c9962afe00e503e2d96abab4e8998a0f84d4230fa57afe1e0528473698cdd9",
+                "sha256:39504670abb5dae77f56f8eb63823937ce727d7cdd0088e6909e6dcac0f89043",
+                "sha256:43f52d4c6a0be301d53ebd867de05e2926c35728b3260157d274635a0a947f1c",
+                "sha256:487e7d50710661116325747a9cd1744d3323f8e49748e287bc9e659060ec6bf9",
+                "sha256:54a935085f7bf101f86b2aff75bd9672b435f51c3339db2ff616e66845f2b8f9",
+                "sha256:c883c2d6670042c7bc1688645cac73dd2b03193d1f7a6847b6154e96890be06d",
+                "sha256:d1d6729c85acea5423671382868627129432fba9a89ecbb248d8d1c7a9f01c67",
+                "sha256:ddc93b6d41cfb81266a27d23a79e13805d4a5521032b512643af8729041a81b4",
+                "sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589"
             ],
-            "version": "==2017.3"
+            "index": "pypi",
+            "version": "==2017.2"
         },
         "requests": {
             "hashes": [
@@ -240,36 +262,39 @@
         },
         "six": {
             "hashes": [
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
+            "index": "pypi",
             "version": "==1.11.0"
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89",
-                "sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128"
+                "sha256:919f26a68b2c17a7634da993d91339e288964f93c274f1343e3bbbe2096e1128",
+                "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
             ],
             "version": "==1.2.1"
         },
         "sphinx": {
             "hashes": [
-                "sha256:b8baed19394af85b21755c68c7ec4eac57e8a482ed89cd01cd5d5ff72200fe0f",
-                "sha256:c39a6fa41bd3ec6fc10064329a664ed3a3ca2e27640a823dc520c682e4433cdb"
+                "sha256:2e7ad92e96eff1b2006cf9f0cdb2743dacbae63755458594e9e8238b0c3dc60b",
+                "sha256:e9b1a75a3eae05dded19c80eb17325be675e0698975baae976df603b6ed1eb10"
             ],
-            "version": "==1.6.6"
+            "index": "pypi",
+            "version": "==1.7.4"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:62ee4752716e698bad7de8a18906f42d33664128eea06c46b718fc7fbd1a9f5c",
-                "sha256:2df74b8ff6fae6965c527e97cca6c6c944886aae474b490e17f92adfbe843417"
+                "sha256:32424dac2779f0840b4788fbccb032ba2496c1ca47a439ad2510c8b1e55dfd33",
+                "sha256:6d0481532b5f441b075127a2d755f430f1f8410a50112b1af6b069518548381d"
             ],
-            "version": "==0.2.4"
+            "index": "pypi",
+            "version": "==0.3.1"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
-                "sha256:f4932e95869599b89bf4f80fc3989132d83c9faa5bf633e7b5e0c25dffb75da2",
-                "sha256:7a85961326aa3a400cd4ad3c816d70ed6f7c740acd7ce5d78cd0a67825072eb9"
+                "sha256:7a85961326aa3a400cd4ad3c816d70ed6f7c740acd7ce5d78cd0a67825072eb9",
+                "sha256:f4932e95869599b89bf4f80fc3989132d83c9faa5bf633e7b5e0c25dffb75da2"
             ],
             "version": "==1.0.1"
         },

--- a/django_graph_api/__init__.py
+++ b/django_graph_api/__init__.py
@@ -1,6 +1,5 @@
 __version__ = '0.2.0'
 
-from .graphql.schema import BaseQueryRoot
 from .graphql.types import (
     BooleanField,
     CharField,
@@ -12,13 +11,15 @@ from .graphql.types import (
     RelatedField,
 )
 from .views import GraphQLView
-__all__ = ('BaseQueryRoot',
-           'BooleanField',
-           'CharField',
-           'FloatField',
-           'IdField',
-           'IntegerField',
-           'ManyRelatedField',
-           'Object',
-           'RelatedField',
-           'GraphQLView')
+
+__all__ = (
+    'BooleanField',
+    'CharField',
+    'FloatField',
+    'IdField',
+    'IntegerField',
+    'ManyRelatedField',
+    'Object',
+    'RelatedField',
+    'GraphQLView',
+)

--- a/django_graph_api/graphql/introspection.py
+++ b/django_graph_api/graphql/introspection.py
@@ -284,11 +284,11 @@ class Schema(Object):
         )
 
     def get_types(self):
-        types = self._collect_types(self.data)
+        types = self._collect_types(self.data.query_root_class)
         return sorted(types, key=self._type_key)
 
     def get_queryType(self):
-        return self.data
+        return self.data.query_root_class
 
     def get_mutationType(self):
         return None

--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -64,9 +64,13 @@ class CombinedQueryRoot(six.with_metaclass(CombinedQueryRootMetaclass, Object)):
             for query_root in self.query_roots:
                 if field_name in query_root._declared_fields:
                     return getattr(query_root, attr)
-        raise AttributeError('{} not found on {} or its query_root_classes'.format(
-            attr,
+            raise AttributeError('{} resolver not found on {} or its query_root_classes'.format(
+                attr,
+                self.__class__.__name__,
+            ))
+        raise AttributeError("{} instance has no attribute '{}'".format(
             self.__class__.__name__,
+            attr,
         ))
 
 

--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -98,7 +98,12 @@ class Schema(object):
     def __init__(self, query_root_classes=None):
         all_query_root_classes = [
             IntrospectionQueryRoot,
-        ] + (query_root_classes or [])
+        ]
+        if query_root_classes:
+            try:
+                all_query_root_classes.extend(query_root_classes)
+            except TypeError:
+                all_query_root_classes.append(query_root_classes)
 
         class QueryRoot(CombinedQueryRoot):
             query_root_classes = all_query_root_classes

--- a/django_graph_api/graphql/types.py
+++ b/django_graph_api/graphql/types.py
@@ -313,6 +313,9 @@ class Object(six.with_metaclass(ObjectMetaclass)):
         self.variables = variables or {}
         self.errors = []
 
+    def get_declared_fields(self):
+        return self._declared_fields
+
     @property
     def fields(self):
         if not hasattr(self, '_fields'):
@@ -324,13 +327,15 @@ class Object(six.with_metaclass(ObjectMetaclass)):
                 object_type=self.__class__,
             )
 
+            declared_fields = self.get_declared_fields()
+
             # Copy the field instances so that obj instances have
             # isolated field instances that they can modify safely.
             # Only copy field instances that are selected.
             # If the field doesn't exist, create a dummy field that returns None
             for selection in selections:
                 try:
-                    field = copy.deepcopy(self._declared_fields[selection.name])
+                    field = copy.deepcopy(declared_fields[selection.name])
                 except KeyError:
                     self.errors.append(
                         GraphQLError('{} does not have field {}'.format(self.object_name, selection.name))

--- a/django_graph_api/graphql/types.py
+++ b/django_graph_api/graphql/types.py
@@ -313,9 +313,6 @@ class Object(six.with_metaclass(ObjectMetaclass)):
         self.variables = variables or {}
         self.errors = []
 
-    def get_declared_fields(self):
-        return self._declared_fields
-
     @property
     def fields(self):
         if not hasattr(self, '_fields'):
@@ -327,15 +324,13 @@ class Object(six.with_metaclass(ObjectMetaclass)):
                 object_type=self.__class__,
             )
 
-            declared_fields = self.get_declared_fields()
-
             # Copy the field instances so that obj instances have
             # isolated field instances that they can modify safely.
             # Only copy field instances that are selected.
             # If the field doesn't exist, create a dummy field that returns None
             for selection in selections:
                 try:
-                    field = copy.deepcopy(declared_fields[selection.name])
+                    field = copy.deepcopy(self._declared_fields[selection.name])
                 except KeyError:
                     self.errors.append(
                         GraphQLError('{} does not have field {}'.format(self.object_name, selection.name))

--- a/django_graph_api/tests/test_arguments.py
+++ b/django_graph_api/tests/test_arguments.py
@@ -97,7 +97,7 @@ def test_episode_name_field_description(starwars_data):
       }
     }"""
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert errors == []
     types = data['__schema']['types']
@@ -122,7 +122,7 @@ def test_episode_and_characters(starwars_data):
         }
         '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episode': {
@@ -154,7 +154,7 @@ def test_episodes_and_droids(starwars_data):
         }
         '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episodes': [

--- a/django_graph_api/tests/test_basic.py
+++ b/django_graph_api/tests/test_basic.py
@@ -13,7 +13,7 @@ def test_hero_name(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'hero': {
@@ -38,7 +38,7 @@ def test_hero_name_and_friends_names(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'hero': {
@@ -78,7 +78,7 @@ def test_hero_name_and_episodes(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'hero': {

--- a/django_graph_api/tests/test_errors.py
+++ b/django_graph_api/tests/test_errors.py
@@ -14,7 +14,7 @@ def test_non_existent_episode(starwars_data):
         }
         '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         "episode": None
@@ -34,7 +34,7 @@ def test_non_existent_field(starwars_data):
         }
         '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         "episode": {

--- a/django_graph_api/tests/test_fragments.py
+++ b/django_graph_api/tests/test_fragments.py
@@ -26,7 +26,7 @@ def test_fragments(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episodes': [
@@ -65,7 +65,7 @@ def test_fragments__nested(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'hero': {
@@ -95,7 +95,7 @@ def test_fragments__recursive(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'hero': {
@@ -124,7 +124,7 @@ def test_fragments__inline(starwars_data):
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episodes': [

--- a/django_graph_api/tests/test_introspection.py
+++ b/django_graph_api/tests/test_introspection.py
@@ -32,13 +32,14 @@ from test_app.schema import (
 
 
 def test_schema__get_types():
-    schema_object = SchemaIntrospector(None, QueryRoot, None)
+    schema = Schema([QueryRoot])
+    schema_object = SchemaIntrospector(None, schema, None)
 
     types = schema_object.get_types()
     assert types == [
         Character,
         Episode,
-        QueryRoot,
+        schema.query_root_class,
         Directive,
         DirectiveLocationEnum,
         EnumValue,

--- a/django_graph_api/tests/test_introspection.py
+++ b/django_graph_api/tests/test_introspection.py
@@ -370,7 +370,7 @@ def test_execute__filter_type():
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         '__type': {
@@ -447,7 +447,7 @@ def test_execute__introspect_directives():
     }
     '''
     request = Request(document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         '__schema': {

--- a/django_graph_api/tests/test_schema.py
+++ b/django_graph_api/tests/test_schema.py
@@ -25,16 +25,22 @@ class ThoughtQueryRoot(Object):
 
 def test_instrospection_always_enabled():
     schema = Schema()
-    assert schema.query_root_classes == [IntrospectionQueryRoot]
+    assert '__schema' in schema.query_root_class._declared_fields
+    assert '__type' in schema.query_root_class._declared_fields
 
 
 def test_accepts_multiple_query_roots():
     schema = Schema([NameQueryRootOne, ThoughtQueryRoot])
-    assert schema.query_root_classes == [
+    assert schema.query_root_class.query_root_classes == [
         IntrospectionQueryRoot,
         NameQueryRootOne,
         ThoughtQueryRoot,
     ]
+    assert set(schema.query_root_class._declared_fields) == (
+        set(IntrospectionQueryRoot._declared_fields) |
+        set(NameQueryRootOne._declared_fields) |
+        set(ThoughtQueryRoot._declared_fields)
+    )
 
 
 def test_schema_detects_duplicate_fields():

--- a/django_graph_api/tests/test_schema.py
+++ b/django_graph_api/tests/test_schema.py
@@ -29,8 +29,37 @@ def test_instrospection_always_enabled():
     assert '__type' in schema.query_root_class._declared_fields
 
 
+def test_accepts_single_query_root():
+    schema = Schema(NameQueryRootOne)
+    assert schema.query_root_class.query_root_classes == [
+        IntrospectionQueryRoot,
+        NameQueryRootOne,
+    ]
+    assert set(schema.query_root_class._declared_fields) == (
+        set(IntrospectionQueryRoot._declared_fields) |
+        set(NameQueryRootOne._declared_fields)
+    )
+
+
 def test_accepts_multiple_query_roots():
     schema = Schema([NameQueryRootOne, ThoughtQueryRoot])
+    assert schema.query_root_class.query_root_classes == [
+        IntrospectionQueryRoot,
+        NameQueryRootOne,
+        ThoughtQueryRoot,
+    ]
+    assert set(schema.query_root_class._declared_fields) == (
+        set(IntrospectionQueryRoot._declared_fields) |
+        set(NameQueryRootOne._declared_fields) |
+        set(ThoughtQueryRoot._declared_fields)
+    )
+
+
+def test_accepts_iterable():
+    schema = Schema(
+        query_root
+        for query_root in [NameQueryRootOne, ThoughtQueryRoot]
+    )
     assert schema.query_root_class.query_root_classes == [
         IntrospectionQueryRoot,
         NameQueryRootOne,

--- a/django_graph_api/tests/test_schema.py
+++ b/django_graph_api/tests/test_schema.py
@@ -1,0 +1,42 @@
+from django.core.exceptions import ImproperlyConfigured
+import pytest
+
+from django_graph_api.graphql.schema import (
+    IntrospectionQueryRoot,
+    Schema,
+)
+from django_graph_api.graphql.types import (
+    CharField,
+    Object,
+)
+
+
+class NameQueryRootOne(Object):
+    name = CharField()
+
+
+class NameQueryRootTwo(Object):
+    name = CharField()
+
+
+class ThoughtQueryRoot(Object):
+    thought = CharField()
+
+
+def test_instrospection_always_enabled():
+    schema = Schema()
+    assert schema.query_root_classes == [IntrospectionQueryRoot]
+
+
+def test_accepts_multiple_query_roots():
+    schema = Schema([NameQueryRootOne, ThoughtQueryRoot])
+    assert schema.query_root_classes == [
+        IntrospectionQueryRoot,
+        NameQueryRootOne,
+        ThoughtQueryRoot,
+    ]
+
+
+def test_schema_detects_duplicate_fields():
+    with pytest.raises(ImproperlyConfigured):
+        Schema([NameQueryRootOne, NameQueryRootTwo])

--- a/django_graph_api/tests/test_variables.py
+++ b/django_graph_api/tests/test_variables.py
@@ -17,7 +17,7 @@ def test_query_default_episode_and_characters(starwars_data):
         }
         '''
     request = Request(document=document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episode': {
@@ -45,7 +45,7 @@ def test_query_missing_variable_no_default(starwars_data):
         }
         '''
     request = Request(document=document)
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episodes': [{
@@ -70,7 +70,7 @@ def test_query_episodes_and_droids(starwars_data):
         }
         '''
     request = Request(document=document, variables={'type': 'droid'})
-    schema = Schema(query_root_class=QueryRoot)
+    schema = Schema(query_root_classes=[QueryRoot])
     data, errors = schema.execute(request)
     assert data == {
         'episodes': [

--- a/django_graph_api/views.py
+++ b/django_graph_api/views.py
@@ -25,7 +25,7 @@ class GraphQLView(View):
     graphiql_version = '0.11.11'
     graphql_url = '/graphql'
     template_name = 'django_graph_api/graphiql.html'
-    query_root_class = None
+    schema = None
 
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(csrf_protect)
@@ -64,8 +64,7 @@ class GraphQLView(View):
         data = None
         errors = graphql_request.errors
         if not graphql_request.errors:
-            schema = Schema(query_root_class=self.query_root_class)
-            data, errors = schema.execute(graphql_request)
+            data, errors = self.schema.execute(graphql_request)
 
         return JsonResponse({
             'data': data,

--- a/django_graph_api/views.py
+++ b/django_graph_api/views.py
@@ -10,7 +10,6 @@ from django.views.decorators.csrf import (
 from django.views.generic import View
 
 from django_graph_api.graphql.request import Request
-from django_graph_api.graphql.schema import Schema
 
 
 class GraphQLView(View):

--- a/docs/define_schema.rst
+++ b/docs/define_schema.rst
@@ -173,18 +173,31 @@ Defining query roots
 --------------------
 
 By defining query roots, you can control how the user can access the schema.
+You can pass a single query root or an iterable of query roots to a schema on instantiation.
+Passing multiple query roots is the recommended method for setting up decoupled apps within a project.
 ::
 
     from django_graph_api import RelatedField
     from .models import Character as CharacterModel
     from .models import Episode as EpisodeModel
 
-    @schema.register_query_root
     class QueryRoot(Object):
         hero = RelatedField(Character)
 
         def get_hero(self):
             return CharacterModel.objects.get(name='R2-D2')
+
+    schema = Schema(QueryRoot)
+
+    # Or:
+
+    schema = Schema([EmailQueryRoot, BlogQueryRoot])
+
+
+.. note::
+    Field names on query roots must be unique within a schema instance.
+    A query root that declares a particular field will also be responsible for resolving it.
+
 
 Sample queries
 --------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -33,14 +33,13 @@ In a new file named ``schema.py``:
     from django_graph_api import Schema
     from django_graph_api import CharField
 
-    schema = Schema()
-
-    @schema.register_query_root
     class QueryRoot(Object):
         hello = CharField()
 
         def get_hello(self):
             return 'world'
+
+    schema = Schema(QueryRoot)
 
 Set up a url to access the schema
 ---------------------------------

--- a/test_app/schema.py
+++ b/test_app/schema.py
@@ -1,6 +1,5 @@
 from django.db.models import Q
 
-from django_graph_api.graphql.schema import BaseQueryRoot
 from django_graph_api.graphql.types import (
     Object,
     CharField,
@@ -11,6 +10,7 @@ from django_graph_api.graphql.types import (
     List,
     String
 )
+from django_graph_api.graphql.schema import Schema
 
 from .models import (
     Character as CharacterModel,
@@ -53,7 +53,7 @@ class Character(Object):
         return self.data.friends.order_by('pk').first()
 
 
-class QueryRoot(BaseQueryRoot):
+class QueryRoot(Object):
     hero = RelatedField(Character, null=False)
     episodes = ManyRelatedField(Episode, arguments={'number': List(Int(null=False))})
     episode = RelatedField(Episode,
@@ -72,3 +72,6 @@ class QueryRoot(BaseQueryRoot):
 
     def get_episode(self, number):
         return EpisodeModel.objects.get(number=number)
+
+
+schema = Schema([QueryRoot])

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -2,10 +2,10 @@ from django.conf.urls import url
 from django.contrib import admin
 
 from django_graph_api.views import GraphQLView
-from test_app.schema import QueryRoot
+from test_app.schema import schema
 
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^graphql$', GraphQLView.as_view(query_root_class=QueryRoot)),
+    url(r'^graphql$', GraphQLView.as_view(schema=schema)),
 ]


### PR DESCRIPTION
This PR enables schema to take a list of query root classes on instantiation and combine them in a well-defined and introspectable way for further use.

I have concerns about the combination method - namely, I feel hesitant about dynamically creating the combined query root class. The API as written is:

```
# schema.py
schema = Schema([query_root1, query_root2])

# urls.py
GraphQLView.as_view(schema=schema)
```

I suspect one of the following may be easier to work with, but I'm not sure:

```
# schema.py
class MySchema(Schema):
    query_root_classes = [query_root1, query_root2]
    # or
    query_root_class = combine_query_roots([query_root1, query_root2])

# urls.py
GraphQLView.as_view(schema_class=MySchema)
```