### PR TITLE
105 parsing null

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,13 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+
 django = "==1.11.4"
 ply = "==3.10"
 pytz = "==2017.2"
-"graphql-py" = "==0.6.1"
+"graphql-py" = "==0.7.1"
 six = "*"
 
 [dev-packages]
+
 "backports.unittest-mock" = "==1.2"
 configparser = "==3.5.0"
 "enum34" = "==1.1.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "edc9fa4d08594e10d5a2144a87ce72e92c864c0f043f28c6f947672cf1d378f7"
+            "sha256": "673bb6fbf63bc300abfc280b32bc78e2262d0c3852315b99219048226c1c8616"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "17.4.0",
+            "platform_release": "17.6.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.6.0: Tue May  8 15:22:16 PDT 2018; root:xnu-4570.61.1~1/RELEASE_X86_64",
             "python_full_version": "3.6.2",
             "python_version": "3.6",
             "sys_platform": "darwin"
@@ -36,9 +36,9 @@
         },
         "graphql-py": {
             "hashes": [
-                "sha256:c4d7cbfdda0d6389b639dc981fa87716c41a7b1196a47ba275471e70e9997f80"
+                "sha256:1279f3fbc30b154ef9c46850bdc15be13d845a01ba68d516a8a4088ba66a710b"
             ],
-            "version": "==0.6.1"
+            "version": "==0.7.1"
         },
         "ply": {
             "hashes": [
@@ -71,17 +71,17 @@
     "develop": {
         "alabaster": {
             "hashes": [
-                "sha256:2eef172f44e8d301d25aff8068fddd65f767a3f04b5f15b0f4922f113aa1c732",
-                "sha256:37cdcb9e9954ed60912ebc1ca12a9d12178c26637abdf124e3cde2341c257fe0"
+                "sha256:674bb3bab080f598371f4443c5008cbfeb1a5e622dd312395d2d82af2c54c456",
+                "sha256:b63b1f4dc77c074d386752ec4a8a7517600f6c0db8cd42980cae17ab7b3275d7"
             ],
-            "version": "==0.7.10"
+            "version": "==0.7.11"
         },
         "babel": {
             "hashes": [
-                "sha256:ad209a68d7162c4cff4b29cdebe3dec4cef75492df501b0049a9433c96ce6f80",
-                "sha256:8ce4cb6fdd4393edd323227cba3a077bceb2a6ce5201c902c65e730046f41f14"
+                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
+                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
             ],
-            "version": "==2.5.3"
+            "version": "==2.6.0"
         },
         "backports.unittest-mock": {
             "hashes": [
@@ -136,10 +136,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
             ],
-            "version": "==2.6"
+            "version": "==2.7"
         },
         "imagesize": {
             "hashes": [
@@ -244,10 +244,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
+                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "version": "==2.18.4"
+            "version": "==2.19.1"
         },
         "six": {
             "hashes": [
@@ -265,31 +265,31 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:2e7ad92e96eff1b2006cf9f0cdb2743dacbae63755458594e9e8238b0c3dc60b",
-                "sha256:e9b1a75a3eae05dded19c80eb17325be675e0698975baae976df603b6ed1eb10"
+                "sha256:85f7e32c8ef07f4ba5aeca728e0f7717bef0789fba8458b8d9c5c294cad134f3",
+                "sha256:d45480a229edf70d84ca9fae3784162b1bc75ee47e480ffe04a4b7f21a95d76d"
             ],
-            "version": "==1.7.4"
+            "version": "==1.7.5"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:32424dac2779f0840b4788fbccb032ba2496c1ca47a439ad2510c8b1e55dfd33",
-                "sha256:6d0481532b5f441b075127a2d755f430f1f8410a50112b1af6b069518548381d"
+                "sha256:aa3e190392e963551432de7df24b8a5fbe5b71a2f4fcd9d5b75808b52ad999e5",
+                "sha256:de88d637a60371d4f923e06b79c4ba260490c57d2ab5a8316942ab5d9a6ce1bf"
             ],
-            "version": "==0.3.1"
+            "version": "==0.4.0"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
-                "sha256:f4932e95869599b89bf4f80fc3989132d83c9faa5bf633e7b5e0c25dffb75da2",
-                "sha256:7a85961326aa3a400cd4ad3c816d70ed6f7c740acd7ce5d78cd0a67825072eb9"
+                "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
+                "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5",
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"
             ],
-            "version": "==1.22"
+            "version": "==1.23"
         }
     }
 }

--- a/django_graph_api/graphql/ast_helpers.py
+++ b/django_graph_api/graphql/ast_helpers.py
@@ -11,8 +11,6 @@ def get_input_value(value, variables, variable_definitions):
         variable_name = value.name
         default_value = variable_definitions[variable_name].default_value
         value = variables.get(variable_name, default_value)
-    if value == 'null':
-        value = None
     if isinstance(value, list):
         return [get_input_value(item, variables, variable_definitions) for item in value]
     return value

--- a/django_graph_api/graphql/types.py
+++ b/django_graph_api/graphql/types.py
@@ -217,12 +217,10 @@ class Boolean(Scalar):
     def coerce_input(cls, value):
         if value is None:
             return None
-        if value == 'true' or value is True:
-            return True
-        elif value == 'false' or value is False:
-            return False
+        if isinstance(value, bool):
+            return value
         raise ValueError(
-            "Could not coerce {} of type {} to boolean. Must be 'true' or 'false'".format(value, type(value).__name__)
+            "Could not coerce {} of type {} to boolean. Must be true or false".format(value, type(value).__name__)
         )
 
 

--- a/django_graph_api/tests/graphql/test_types.py
+++ b/django_graph_api/tests/graphql/test_types.py
@@ -174,9 +174,9 @@ def test_boolean_coerce_input():
     with pytest.raises(ValueError):
         Boolean.coerce_input(0)
     with pytest.raises(ValueError):
-        Boolean.coerce_input('True')
+        Boolean.coerce_input('true')
     with pytest.raises(ValueError):
-        Boolean.coerce_input(1.0)
+        Boolean.coerce_input('False')
 
 
 def test_list_coerce_result():

--- a/django_graph_api/tests/validation/test_operations.py
+++ b/django_graph_api/tests/validation/test_operations.py
@@ -84,7 +84,7 @@ def test_named_operation__uniqueness__different_types():
 
 def test_anonymous_operation__valid_document():
     document = '''
-    {
+    query {
       dog {
         name
       }

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for readthedocs until they add pipfile support
 django==1.11.4
-graphql-py==0.6
+graphql-py==0.7.1
 ply==3.10
 pytz==2017.2


### PR DESCRIPTION
Since graphql-py got updated, we can now update to the latest version and stop expecting null/true/false inputs as strings. Also adds test to include an anonymous query with an operation type that doesn't return a parse error.

Fixes #105 